### PR TITLE
Updated Readme with correct NPM module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A node.js PDF form field data filler and FDF generator toolkit. This essentially
 Quick start
 -----------
 
-First, run `npm install pdffiller --save` for your app. Then, in an Express app:
+First, run `npm install node-pdffiller --save` for your app. Then, in an Express app:
 
 ```js
 var pdfFiller = require('pdffiller');


### PR DESCRIPTION
The current readme suggests the outdated 'pdffiller' module, which is v0.0.0. Have corrected it to the right one ('node-pdffiller', v0.0.5).