### PR TITLE
Using tmp module to create fdf files

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,9 +112,7 @@
             //Generate the data from the field values.
             var tmpFileobj = tmp.fileSync({unsafeCleanup:false});
             var formData = fdf.generate( fieldValues ),
-                //tempFDF = "data" + (new Date().getTime()) + ".fdf";
-                tempFDF= tmpFileobj.name+".data" + (new Date().getTime()) +".fdf";
-            console.log('created Temp File - '+tempFDF);
+                tempFDF= tmpFileobj.name+'.'+new Date().getTime() +".fdf";
 
             //Write the temp fdf file.
             fs.writeFile( tempFDF, formData, function( err ) {

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@
                 } catch(err){
 
                     return key;
-                } 
+                }
                 return convMap[key];
             });
 
@@ -55,7 +55,7 @@
                 regFlags = /FieldFlags: ([0-9\t .]+)/,
                 fieldArray = [],
                 currField = {};
-            
+
             if(nameRegex !== null && (typeof nameRegex) == 'object' ) regName = nameRegex;
 
             exec( "pdftk " + sourceFile + " dump_data_fields_utf8 " , function (error, stdout, stderr) {
@@ -63,34 +63,34 @@
                     console.log('exec error: ' + error);
                     return callback(error, null);
                 }
-                
+
                 fields = stdout.toString().split("---").slice(1);
                 fields.forEach(function(field){
                     currField = {};
-                    
-                    currField['title'] = field.match(regName)[1].trim() || ''; 
+
+                    currField['title'] = field.match(regName)[1].trim() || '';
 
                     if(field.match(regType)){
-                        currField['fieldType'] = field.match(regType)[1].trim() || '';  
+                        currField['fieldType'] = field.match(regType)[1].trim() || '';
                     }else {
                         currField['fieldType'] = '';
                     }
 
                     if(field.match(regFlags)){
                         currField['fieldFlags'] = field.match(regFlags)[1].trim()|| '';
-                    }else{ 
+                    }else{
                         currField['fieldFlags'] = '';
                     }
 
                     currField['fieldValue'] = '';
-                    
+
                     fieldArray.push(currField);
                 });
-                
+
                 return callback(null, fieldArray);
             });
         },
-        
+
         generateFDFTemplate: function( sourceFile, nameRegex, callback ){
             this.generateFieldJson(sourceFile, nameRegex, function(err, _form_fields){
                 if (err) {
@@ -100,9 +100,9 @@
                 var _keys   = _.pluck(_form_fields, 'title'),
             	    _values = _.pluck(_form_fields, 'fieldValue'),
                     jsonObj = _.zipObject(_keys, _values);
-                
+
                 return callback(null, jsonObj);
-                
+
             });
         },
 
@@ -111,6 +111,7 @@
             //Generate the data from the field values.
             var formData = fdf.generate( fieldValues ),
                 tempFDF = "data" + (new Date().getTime()) + ".fdf";
+            console.log('created Temp File - '+tempFDF);
 
             //Write the temp fdf file.
             fs.writeFile( tempFDF, formData, function( err ) {

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@
     var sys = require('sys'),
         child_process = require('child_process'),
         exec = require('child_process').exec,
+        tmp=require('tmp'),
         fdf = require('fdf'),
         _ = require('lodash'),
         fs = require('fs');
@@ -109,8 +110,10 @@
         fillForm: function( sourceFile, destinationFile, fieldValues, callback ) {
 
             //Generate the data from the field values.
+            var tmpFileobj = tmp.fileSync({unsafeCleanup:false});
             var formData = fdf.generate( fieldValues ),
-                tempFDF = "data" + (new Date().getTime()) + ".fdf";
+                //tempFDF = "data" + (new Date().getTime()) + ".fdf";
+                tempFDF= tmpFileobj.name+".data" + (new Date().getTime()) +".fdf";
             console.log('created Temp File - '+tempFDF);
 
             //Write the temp fdf file.

--- a/index.js
+++ b/index.js
@@ -110,6 +110,7 @@
         fillForm: function( sourceFile, destinationFile, fieldValues, callback ) {
 
             //Generate the data from the field values.
+            tmp.setGracefulCleanup();
             var tmpFileobj = tmp.fileSync({unsafeCleanup:false});
             var formData = fdf.generate( fieldValues ),
                 tempFDF= tmpFileobj.name+'.'+new Date().getTime() +".fdf";

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pdffiller",
+  "name": "pdffiller-concurrent",
   "version": "0.0.7",
   "private": false,
   "description": "Take an existing PDF Form and data and PDF Filler will create a new PDF with all given fields populated.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdffiller-concurrent",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "private": false,
   "description": "Take an existing PDF Form and data and PDF Filler will create a new PDF with all given fields populated.",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "pdffiller",
-  "version": "0.0.8",
+  "name": "pdffiller-concurrent",
+  "version": "0.0.9",
   "private": false,
   "description": "Take an existing PDF Form and data and PDF Filler will create a new PDF with all given fields populated.",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "fdf": "*",
     "lodash": "~3.8.0",
-    "should": "6.0.1"
+    "should": "6.0.1",
+    "tmp": "0.0.28"
   },
   "author": {
     "name": "John Taylor and David Baldwynn"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "pdffiller-concurrent",
-  "version": "0.0.9",
+  "name": "pdffiller",
+  "version": "0.0.88888888",
   "private": false,
   "description": "Take an existing PDF Form and data and PDF Filler will create a new PDF with all given fields populated.",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdffiller",
-  "version": "0.0.88888888",
+  "version": "0.0.8",
   "private": false,
   "description": "Take an existing PDF Form and data and PDF Filler will create a new PDF with all given fields populated.",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdffiller-concurrent",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "private": false,
   "description": "Take an existing PDF Form and data and PDF Filler will create a new PDF with all given fields populated.",
   "main": "index.js",


### PR DESCRIPTION
Hey - I was filling multiple PDFs asynchronously (ran in to a conflict with .fdf file names) and realized that the below way of creating temp .fdf is not scaling for my needs.

tempFDF = "data" + (new Date().getTime()) + ".fdf";

I changed the line to use 'tmp' module, and make necessary changes in package.json

 tempFDF= tmpFileobj.name+'.'+new Date().getTime() +".fdf";

Thanks,
Hari