### PR TITLE
Remove unused sys variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,7 @@
 *                PDF file with the form fields populated.
 */
 (function(){
-    var sys = require('sys'),
-        child_process = require('child_process'),
+    var child_process = require('child_process'),
         exec = require('child_process').exec,
         fdf = require('fdf'),
         _ = require('lodash'),


### PR DESCRIPTION
I was getting a 'sys' deprecation message, but it looks like 'sys' is not even used.