### PR TITLE
add mocha dependency and fix test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Take an existing PDF Form and data and PDF Filler will create a new PDF with all given fields populated.",
   "main": "index.js",
   "scripts": {
-    "test": "node test/test.js"
+    "test": "mocha test/test.js"
   },
   "keywords": [
     "nodejs",
@@ -29,5 +29,8 @@
   "_id": "pdffiller@0.0.5",
   "_shasum": "416c724b748a5e0caf494fb66b043d450b8a3b9a",
   "_from": "whitef0x0/pdffiller",
-  "_resolved": "git://github.com/whitef0x0/pdffiller.git#dc344fd81d90d0434dcc253d9ee14e4328b680dd"
+  "_resolved": "git://github.com/whitef0x0/pdffiller.git#dc344fd81d90d0434dcc253d9ee14e4328b680dd",
+  "devDependencies": {
+    "mocha": "^2.4.5"
+  }
 }


### PR DESCRIPTION
Here, now `npm test` works as a command for running the tests and mocha is installed for the purpose of testing so it's not required as an external dependency.
