### PR TITLE
Support utf8 in fdf generation

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@
 (function(){
     var child_process = require('child_process'),
         exec = require('child_process').exec,
-        fdf = require('fdf'),
+        fdf = require('utf8-fdf-generator'),
         _ = require('lodash'),
         fs = require('fs');
 
@@ -23,7 +23,7 @@
                 } catch(err){
 
                     return key;
-                } 
+                }
                 return convMap[key];
             });
 
@@ -54,7 +54,7 @@
                 regFlags = /FieldFlags: ([0-9\t .]+)/,
                 fieldArray = [],
                 currField = {};
-            
+
             if(nameRegex !== null && (typeof nameRegex) == 'object' ) regName = nameRegex;
 
             exec( "pdftk " + sourceFile + " dump_data_fields_utf8 " , function (error, stdout, stderr) {
@@ -62,34 +62,34 @@
                     console.log('exec error: ' + error);
                     return callback(error, null);
                 }
-                
+
                 fields = stdout.toString().split("---").slice(1);
                 fields.forEach(function(field){
                     currField = {};
-                    
-                    currField['title'] = field.match(regName)[1].trim() || ''; 
+
+                    currField['title'] = field.match(regName)[1].trim() || '';
 
                     if(field.match(regType)){
-                        currField['fieldType'] = field.match(regType)[1].trim() || '';  
+                        currField['fieldType'] = field.match(regType)[1].trim() || '';
                     }else {
                         currField['fieldType'] = '';
                     }
 
                     if(field.match(regFlags)){
                         currField['fieldFlags'] = field.match(regFlags)[1].trim()|| '';
-                    }else{ 
+                    }else{
                         currField['fieldFlags'] = '';
                     }
 
                     currField['fieldValue'] = '';
-                    
+
                     fieldArray.push(currField);
                 });
-                
+
                 return callback(null, fieldArray);
             });
         },
-        
+
         generateFDFTemplate: function( sourceFile, nameRegex, callback ){
             this.generateFieldJson(sourceFile, nameRegex, function(err, _form_fields){
                 if (err) {
@@ -97,44 +97,36 @@
                   return callback(err, null);
                 }
                 var _keys   = _.pluck(_form_fields, 'title'),
-            	    _values = _.pluck(_form_fields, 'fieldValue'),
+                  _values = _.pluck(_form_fields, 'fieldValue'),
                     jsonObj = _.zipObject(_keys, _values);
-                
+
                 return callback(null, jsonObj);
-                
+
             });
         },
 
         fillForm: function( sourceFile, destinationFile, fieldValues, callback ) {
 
             //Generate the data from the field values.
-            var formData = fdf.generate( fieldValues ),
-                tempFDF = "data" + (new Date().getTime()) + ".fdf";
+            var tempFDF = "data" + (new Date().getTime()) + ".fdf",
+                formData = fdf.generator( fieldValues, tempFDF );
 
-            //Write the temp fdf file.
-            fs.writeFile( tempFDF, formData, function( err ) {
+            child_process.exec( "pdftk " + sourceFile + " fill_form " + tempFDF + " output " + destinationFile + " flatten", function (error, stdout, stderr) {
 
-                if ( err ) {
-                    return callback(err);
+                if ( error ) {
+                    console.log('exec error: ' + error);
+                    return callback(error);
                 }
+                //Delete the temporary fdf file.
+                fs.unlink( tempFDF, function( err ) {
 
-                child_process.exec( "pdftk " + sourceFile + " fill_form " + tempFDF + " output " + destinationFile + " flatten", function (error, stdout, stderr) {
-
-                    if ( error ) {
-                      console.log('exec error: ' + error);
-                      return callback(error);
+                    if ( err ) {
+                        return callback(err);
                     }
-                    //Delete the temporary fdf file.
-                    fs.unlink( tempFDF, function( err ) {
-
-                        if ( err ) {
-                            return callback(err);
-                        }
-                        // console.log( 'Sucessfully deleted temp file ' + tempFDF );
-                        return callback();
-                    });
-                } );
-            });
+                    // console.log( 'Sucessfully deleted temp file ' + tempFDF );
+                    return callback();
+                });
+            } );
         }
     };
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Take an existing PDF Form and data and PDF Filler will create a new PDF with all given fields populated.",
   "main": "index.js",
   "scripts": {
-    "test": "node test/test.js"
+    "test": "node_modules/.bin/mocha test/test.js"
   },
   "keywords": [
     "nodejs",
@@ -29,5 +29,9 @@
   "_id": "pdffiller@0.0.5",
   "_shasum": "416c724b748a5e0caf494fb66b043d450b8a3b9a",
   "_from": "whitef0x0/pdffiller",
-  "_resolved": "git://github.com/whitef0x0/pdffiller.git#dc344fd81d90d0434dcc253d9ee14e4328b680dd"
+  "_resolved": "git://github.com/whitef0x0/pdffiller.git#dc344fd81d90d0434dcc253d9ee14e4328b680dd",
+  "devDependencies": {
+    "mocha": "~2.4.5",
+    "should": "~6.0.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -15,9 +15,8 @@
     "pdf"
   ],
   "dependencies": {
-    "fdf": "*",
     "lodash": "~3.8.0",
-    "should": "6.0.1"
+    "utf8-fdf-generator": "0.0.3"
   },
   "author": {
     "name": "John Taylor and David Baldwynn"

--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,7 @@
 *
 */
 
-var pdfFiller = require('../index'), 
+var pdfFiller = require('../index'),
     should = require('should'),
     expected = require('./expected_data');
 
@@ -35,7 +35,7 @@ describe('pdfFiller Tests', function(){
 
         it('should not throw an error when creating test_complete.pdf from test.pdf with filled data', function(done) {
             this.timeout(15000);
-            pdfFiller.fillForm( source2PDF, dest2PDF, _data, function(err) { 
+            pdfFiller.fillForm( source2PDF, dest2PDF, _data, function(err) {
                 should.not.exist(err);
                 done();
             });
@@ -96,7 +96,7 @@ describe('pdfFiller Tests', function(){
 
         it('should generate form field JSON as expected', function(done){
             this.timeout(15000);
-            pdfFiller.generateFieldJson( source2PDF, null, function(err, form_fields) { 
+            pdfFiller.generateFieldJson( source2PDF, null, function(err, form_fields) {
                 should.not.exist(err);
                 form_fields.should.eql(_expected);
                 done();
@@ -105,7 +105,7 @@ describe('pdfFiller Tests', function(){
 
         it('should generate another form field JSON with no errors', function(done){
             this.timeout(15000);
-            pdfFiller.generateFieldJson( source1PDF, null, function(err, form_fields) { 
+            pdfFiller.generateFieldJson( source1PDF, null, function(err, form_fields) {
                 should.not.exist(err);
                 form_fields.should.eql(expected.test1.form_fields);
                 done();
@@ -128,7 +128,7 @@ describe('pdfFiller Tests', function(){
 
         it('should generate a FDF Template as expected', function(done){
             this.timeout(15000);
-            pdfFiller.generateFDFTemplate( source2PDF, null, function(err, fdfTemplate) { 
+            pdfFiller.generateFDFTemplate( source2PDF, null, function(err, fdfTemplate) {
                 should.not.exist(err);
                 fdfTemplate.should.eql(_expected);
                 done();
@@ -137,9 +137,9 @@ describe('pdfFiller Tests', function(){
 
         it('should generate another FDF Template with no errors', function(done){
             this.timeout(15000);
-            pdfFiller.generateFDFTemplate( source1PDF, null, function(err, fdfTemplate) { 
+            pdfFiller.generateFDFTemplate( source1PDF, null, function(err, fdfTemplate) {
                 should.not.exist(err);
-                fdfTemplate.should.not.eql(expected.test1.fdfTemplate);
+                fdfTemplate.should.eql(expected.test1.fdfTemplate);
                 done();
             });
         });
@@ -157,7 +157,7 @@ describe('pdfFiller Tests', function(){
             "hockey" : "Yes",
             "nascar" : "Off"
         };
-        
+
         var _data = [
             {
                 "title" : "first_name",
@@ -200,7 +200,7 @@ describe('pdfFiller Tests', function(){
                 "fieldValue": false
             }
         ];
-        
+
         it('Should generate an corresponding FDF object', function(done){
             var FDFData = pdfFiller.convFieldJson2FDF( _data );
             should.exist(FDFData);
@@ -222,7 +222,7 @@ describe('pdfFiller Tests', function(){
             "hockeyField": "hockey",
             "nascarField": "nascar"
         };
-        
+
         var _data = [
             {
                 "title" : "lastName",
@@ -265,7 +265,7 @@ describe('pdfFiller Tests', function(){
                 "fieldValue": false
             }
         ];
-        
+
         var _expected = {
             "last_name" : "John",
             "first_name" : "Doe",
@@ -286,8 +286,3 @@ describe('pdfFiller Tests', function(){
     });
 
 });
-
-
-
-
-


### PR DESCRIPTION
I ran into a problem with fdf library used by this lib not supporting utf8. So I fixed the tests and switched it to [utf8-fdf-generator](https://www.npmjs.com/package/utf8-fdf-generator). Also added mocha and should to dev dependencies in the packages.