### PR TITLE
Adding path for temporary FDF files

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,10 +105,11 @@
             });
         },
 
-        fillFormWithFlatten: function( sourceFile, destinationFile, fieldValues, shouldFlatten,  callback ) {
+        fillFormWithFlatten: function( sourceFile, destinationFile, fieldValues, shouldFlatten, tempFDFPath, callback ) {
 
             //Generate the data from the field values.
-            var tempFDF = "data" + (new Date().getTime()) + ".fdf",
+            var tempFDFFile =  "data" + (new Date().getTime()) + ".fdf",
+                tempFDF = (typeof tempFDFPath !== "undefined"? tempFDFPath + '/' + tempFDFFile: tempFDFFile),
                 formData = fdf.generator( fieldValues, tempFDF );
 
             var args = [sourceFile, "fill_form", tempFDF, "output", destinationFile];
@@ -134,7 +135,7 @@
         },
 
         fillForm: function( sourceFile, destinationFile, fieldValues, callback) {
-            this.fillFormWithFlatten( sourceFile, destinationFile, fieldValues, true, callback);
+            this.fillFormWithFlatten( sourceFile, destinationFile, fieldValues, true, undefined, callback);
         }
 
     };

--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@
             });
         },
 
-        fillFormWithFlatten: function( sourceFile, destinationFile, fieldValues, shouldFlatten, tempFDFPath, callback ) {
+        fillFormWithOptions: function( sourceFile, destinationFile, fieldValues, shouldFlatten, tempFDFPath, callback ) {
 
             //Generate the data from the field values.
             var tempFDFFile =  "data" + (new Date().getTime()) + ".fdf",
@@ -134,8 +134,12 @@
             } );
         },
 
+        fillFormWithFlatten: function( sourceFile, destinationFile, fieldValues, shouldFlatten, callback ) {
+            this.fillFormWithOptions( sourceFile, destinationFile, fieldValues, shouldFlatten, undefined, callback);
+        },
+
         fillForm: function( sourceFile, destinationFile, fieldValues, callback) {
-            this.fillFormWithFlatten( sourceFile, destinationFile, fieldValues, true, undefined, callback);
+            this.fillFormWithFlatten( sourceFile, destinationFile, fieldValues, true, callback);
         }
 
     };

--- a/test/test.js
+++ b/test/test.js
@@ -43,7 +43,7 @@ describe('pdfFiller Tests', function(){
 
         it('should create an completely filled PDF that is read-only', function(done) {
             this.timeout(15000);
-            pdfFiller.fillFormWithFlatten( source2PDF, dest2PDF, _data, true, undefined, function(err) {
+            pdfFiller.fillFormWithFlatten( source2PDF, dest2PDF, _data, true, function(err) {
                 pdfFiller.generateFieldJson(dest2PDF, null, function(err, fdfData) {
                     fdfData.length.should.equal(0);
                     done();
@@ -53,7 +53,7 @@ describe('pdfFiller Tests', function(){
 
         it('should create an completely filled PDF that is read-only and with an specific temporary folder for FDF files', function(done) {
             this.timeout(15000);
-            pdfFiller.fillFormWithFlatten( source2PDF, dest2PDF, _data, true, './', function(err) {
+            pdfFiller.fillFormWithOptions( source2PDF, dest2PDF, _data, true, './', function(err) {
                 pdfFiller.generateFieldJson(dest2PDF, null, function(err, fdfData) {
                     fdfData.length.should.equal(0);
                     done();
@@ -68,7 +68,7 @@ describe('pdfFiller Tests', function(){
             var _data2 = {
                 "first_name": "Jerry",
             };
-            pdfFiller.fillFormWithFlatten( source3PDF, dest3PDF, _data2, false, undefined, function(err) {
+            pdfFiller.fillFormWithFlatten( source3PDF, dest3PDF, _data2, false, function(err) {
                 pdfFiller.generateFieldJson(dest3PDF, null, function(err, fdfData) {
                     fdfData.length.should.not.equal(0);
                     done();

--- a/test/test.js
+++ b/test/test.js
@@ -43,7 +43,17 @@ describe('pdfFiller Tests', function(){
 
         it('should create an completely filled PDF that is read-only', function(done) {
             this.timeout(15000);
-            pdfFiller.fillFormWithFlatten( source2PDF, dest2PDF, _data, true, function(err) {
+            pdfFiller.fillFormWithFlatten( source2PDF, dest2PDF, _data, true, undefined, function(err) {
+                pdfFiller.generateFieldJson(dest2PDF, null, function(err, fdfData) {
+                    fdfData.length.should.equal(0);
+                    done();
+                });
+            });
+        });
+
+        it('should create an completely filled PDF that is read-only and with an specific temporary folder for FDF files', function(done) {
+            this.timeout(15000);
+            pdfFiller.fillFormWithFlatten( source2PDF, dest2PDF, _data, true, './', function(err) {
                 pdfFiller.generateFieldJson(dest2PDF, null, function(err, fdfData) {
                     fdfData.length.should.equal(0);
                     done();
@@ -55,10 +65,10 @@ describe('pdfFiller Tests', function(){
             this.timeout(15000);
             var source3PDF = source2PDF;
             var dest3PDF = "test/test_complete3.pdf";
-            var _data2 = { 
+            var _data2 = {
                 "first_name": "Jerry",
             };
-            pdfFiller.fillFormWithFlatten( source3PDF, dest3PDF, _data2, false, function(err) {
+            pdfFiller.fillFormWithFlatten( source3PDF, dest3PDF, _data2, false, undefined, function(err) {
                 pdfFiller.generateFieldJson(dest3PDF, null, function(err, fdfData) {
                     fdfData.length.should.not.equal(0);
                     done();


### PR DESCRIPTION
Main idea is to enable the configuration of the path for the temporary FDF files that are created when filling a form. 

At the moment files are created on the current working directory, which is not always a suitable location and can cause problems. Specially when you run your NodeJS application using process managers such as pm2, forever, etc.