### PR TITLE
Added random alphanumeric sequence to the temp FDF file name

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,9 @@
         fillFormWithOptions: function( sourceFile, destinationFile, fieldValues, shouldFlatten, tempFDFPath, callback ) {
 
             //Generate the data from the field values.
-            var tempFDFFile =  "data" + (new Date().getTime()) + ".fdf",
+            var randomSequence = Math.random().toString(36).substring(7);
+            var currentTime = new Date().getTime();
+            var tempFDFFile =  "data" + currentTime + randomSequence + ".fdf",
                 tempFDF = (typeof tempFDFPath !== "undefined"? tempFDFPath + '/' + tempFDFFile: tempFDFFile),
                 formData = fdf.generator( fieldValues, tempFDF );
 


### PR DESCRIPTION
Using just the timestamp to generate a temporary file name on a multi-threaded environment can be risky. This MR is just adding a random alphanumeric sequence in order to improve the "uniqueness" of the file name and to avoid threads clashing when generating FDF files.
