### PR TITLE
Bug with utf8-fdf-generator

### DIFF
--- a/fdf.js
+++ b/fdf.js
@@ -1,0 +1,57 @@
+var fs = require('fs');
+
+var escapeString = function escapeString(value) {
+    var out = value.toString();
+    out = out.replace(/\\/g, "\\\\");
+    out = out.replace(/\(/g, "\\(");
+    out = out.replace(/\)/g, "\\)");
+    out = out.toString("utf8");
+    console.log(out)
+    return out;
+}
+
+exports.createFdf = function (data, fileName) {
+    var header, body, footer, dataKeys;
+
+    header = Buffer([]);
+    header = Buffer.concat([header, new Buffer("%FDF-1.2\n")]);
+    header = Buffer.concat([header, new Buffer((String.fromCharCode(226)) + (String.fromCharCode(227)) + (String.fromCharCode(207)) + (String.fromCharCode(211)) + "\n")]);
+    header = Buffer.concat([header, new Buffer("1 0 obj \n")]);
+    header = Buffer.concat([header, new Buffer("<<\n")]);
+    header = Buffer.concat([header, new Buffer("/FDF \n")]);
+    header = Buffer.concat([header, new Buffer("<<\n")]);
+    header = Buffer.concat([header, new Buffer("/Fields [\n")]);
+
+    footer = Buffer([]);
+    footer = Buffer.concat([footer, new Buffer("]\n")]);
+    footer = Buffer.concat([footer, new Buffer(">>\n")]);
+    footer = Buffer.concat([footer, new Buffer(">>\n")]);
+    footer = Buffer.concat([footer, new Buffer("endobj \n")]);
+    footer = Buffer.concat([footer, new Buffer("trailer\n")]);
+    footer = Buffer.concat([footer, new Buffer("\n")]);
+    footer = Buffer.concat([footer, new Buffer("<<\n")]);
+    footer = Buffer.concat([footer, new Buffer("/Root 1 0 R\n")]);
+    footer = Buffer.concat([footer, new Buffer(">>\n")]);
+    footer = Buffer.concat([footer, new Buffer("%%EOF\n")]);
+
+    dataKeys = Object.keys(data);
+
+    body = new Buffer([]);
+
+    for (var i = 0; i < dataKeys.length; i++) {
+        var name = dataKeys[i];
+        var value = data[name];
+
+        body = Buffer.concat([body, new Buffer("<<\n")]);
+        body = Buffer.concat([body, new Buffer("/T (")]);
+
+        body = Buffer.concat([body, new Buffer(escapeString(name))]);
+        body = Buffer.concat([body, new Buffer(")\n")]);
+        body = Buffer.concat([body, new Buffer("/V (")]);
+        body = Buffer.concat([body, new Buffer(escapeString(value))]);
+        body = Buffer.concat([body, new Buffer(")\n")]);
+        body = Buffer.concat([body, new Buffer(">>\n")]);
+    }
+
+    fs.writeFileSync(fileName, Buffer.concat([header, body, footer]));
+}

--- a/index.js
+++ b/index.js
@@ -31,8 +31,8 @@
         },
 
         convFieldJson2FDF: function(fieldJson){
-            var _keys = _.pluck(fieldJson, 'title'),
-                _values = _.pluck(fieldJson, 'fieldValue');
+            var _keys = _.map(fieldJson, 'title'),
+                _values = _.map(fieldJson, 'fieldValue');
 
             _values = _.map(_values, function(val){
                 if(val === true){
@@ -96,8 +96,8 @@
                   console.log('exec error: ' + err);
                   return callback(err, null);
                 }
-                var _keys   = _.pluck(_form_fields, 'title'),
-                  _values = _.pluck(_form_fields, 'fieldValue'),
+                var _keys   = _.map(_form_fields, 'title'),
+                  _values = _.map(_form_fields, 'fieldValue'),
                     jsonObj = _.zipObject(_keys, _values);
 
                 return callback(null, jsonObj);

--- a/index.js
+++ b/index.js
@@ -1,26 +1,26 @@
 /*
-*   File:       index.js (pdffiller)
-*   Project:    PDF Filler
-*   Date:       May 2015.
-*
-*   Description: This PDF filler module takes a data set and creates a filled out
-*                PDF file with the form fields populated.
-*/
-(function(){
+ *   File:       index.js (pdffiller)
+ *   Project:    PDF Filler
+ *   Date:       May 2015.
+ *
+ *   Description: This PDF filler module takes a data set and creates a filled out
+ *                PDF file with the form fields populated.
+ */
+(function () {
     var child_process = require('child_process'),
         execFile = require('child_process').execFile,
-        fdf = require('utf8-fdf-generator'),
+        fdf = require("./fdf.js"),
         _ = require('lodash'),
         fs = require('fs');
 
     var pdffiller = {
 
-        mapForm2PDF: function( formFields, convMap ){
+        mapForm2PDF: function (formFields, convMap) {
             var tmpFDFData = this.convFieldJson2FDF(formFields);
-            tmpFDFData = _.mapKeys(tmpFDFData, function(value, key){
+            tmpFDFData = _.mapKeys(tmpFDFData, function (value, key) {
                 try {
                     convMap[key];
-                } catch(err){
+                } catch (err) {
 
                     return key;
                 }
@@ -30,14 +30,14 @@
             return tmpFDFData;
         },
 
-        convFieldJson2FDF: function(fieldJson){
+        convFieldJson2FDF: function (fieldJson) {
             var _keys = _.map(fieldJson, 'title'),
                 _values = _.map(fieldJson, 'fieldValue');
 
-            _values = _.map(_values, function(val){
-                if(val === true){
+            _values = _.map(_values, function (val) {
+                if (val === true) {
                     return 'Yes';
-                }else if(val === false) {
+                } else if (val === false) {
                     return 'Off';
                 }
                 return val;
@@ -48,36 +48,36 @@
             return jsonObj;
         },
 
-        generateFieldJson: function( sourceFile, nameRegex, callback){
+        generateFieldJson: function (sourceFile, nameRegex, callback) {
             var regName = /FieldName: ([^\n]*)/,
                 regType = /FieldType: ([A-Za-z\t .]+)/,
                 regFlags = /FieldFlags: ([0-9\t .]+)/,
                 fieldArray = [],
                 currField = {};
 
-            if(nameRegex !== null && (typeof nameRegex) == 'object' ) regName = nameRegex;
+            if (nameRegex !== null && (typeof nameRegex) == 'object') regName = nameRegex;
 
-            execFile( "pdftk", [sourceFile, "dump_data_fields_utf8"], function (error, stdout, stderr) {
+            execFile("pdftk", [sourceFile, "dump_data_fields_utf8"], function (error, stdout, stderr) {
                 if (error) {
                     console.log('exec error: ' + error);
                     return callback(error, null);
                 }
 
                 fields = stdout.toString().split("---").slice(1);
-                fields.forEach(function(field){
+                fields.forEach(function (field) {
                     currField = {};
 
                     currField['title'] = field.match(regName)[1].trim() || '';
 
-                    if(field.match(regType)){
+                    if (field.match(regType)) {
                         currField['fieldType'] = field.match(regType)[1].trim() || '';
-                    }else {
+                    } else {
                         currField['fieldType'] = '';
                     }
 
-                    if(field.match(regFlags)){
-                        currField['fieldFlags'] = field.match(regFlags)[1].trim()|| '';
-                    }else{
+                    if (field.match(regFlags)) {
+                        currField['fieldFlags'] = field.match(regFlags)[1].trim() || '';
+                    } else {
                         currField['fieldFlags'] = '';
                     }
 
@@ -90,14 +90,14 @@
             });
         },
 
-        generateFDFTemplate: function( sourceFile, nameRegex, callback ){
-            this.generateFieldJson(sourceFile, nameRegex, function(err, _form_fields){
+        generateFDFTemplate: function (sourceFile, nameRegex, callback) {
+            this.generateFieldJson(sourceFile, nameRegex, function (err, _form_fields) {
                 if (err) {
-                  console.log('exec error: ' + err);
-                  return callback(err, null);
+                    console.log('exec error: ' + err);
+                    return callback(err, null);
                 }
-                var _keys   = _.map(_form_fields, 'title'),
-                  _values = _.map(_form_fields, 'fieldValue'),
+                var _keys = _.map(_form_fields, 'title'),
+                    _values = _.map(_form_fields, 'fieldValue'),
                     jsonObj = _.zipObject(_keys, _values);
 
                 return callback(null, jsonObj);
@@ -105,43 +105,43 @@
             });
         },
 
-        fillFormWithOptions: function( sourceFile, destinationFile, fieldValues, shouldFlatten, tempFDFPath, callback ) {
+        fillFormWithOptions: function (sourceFile, destinationFile, fieldValues, shouldFlatten, tempFDFPath, callback) {
 
             //Generate the data from the field values.
             var randomSequence = Math.random().toString(36).substring(7);
             var currentTime = new Date().getTime();
-            var tempFDFFile =  "data" + currentTime + randomSequence + ".fdf",
-                tempFDF = (typeof tempFDFPath !== "undefined"? tempFDFPath + '/' + tempFDFFile: tempFDFFile),
-                formData = fdf.generator( fieldValues, tempFDF );
+            var tempFDFFile = "data" + currentTime + randomSequence + ".fdf",
+                tempFDF = (typeof tempFDFPath !== "undefined" ? tempFDFPath + '/' + tempFDFFile : tempFDFFile),
+                formData = fdf.createFdf(fieldValues, tempFDF);
 
             var args = [sourceFile, "fill_form", tempFDF, "output", destinationFile];
             if (shouldFlatten) {
                 args.push("flatten");
             }
-            execFile( "pdftk", args, function (error, stdout, stderr) {
+            execFile("pdftk", args, function (error, stdout, stderr) {
 
-                if ( error ) {
+                if (error) {
                     console.log('exec error: ' + error);
                     return callback(error);
                 }
                 //Delete the temporary fdf file.
-                fs.unlink( tempFDF, function( err ) {
+                fs.unlink(tempFDF, function (err) {
 
-                    if ( err ) {
+                    if (err) {
                         return callback(err);
                     }
                     // console.log( 'Sucessfully deleted temp file ' + tempFDF );
                     return callback();
                 });
-            } );
+            });
         },
 
-        fillFormWithFlatten: function( sourceFile, destinationFile, fieldValues, shouldFlatten, callback ) {
-            this.fillFormWithOptions( sourceFile, destinationFile, fieldValues, shouldFlatten, undefined, callback);
+        fillFormWithFlatten: function (sourceFile, destinationFile, fieldValues, shouldFlatten, callback) {
+            this.fillFormWithOptions(sourceFile, destinationFile, fieldValues, shouldFlatten, undefined, callback);
         },
 
-        fillForm: function( sourceFile, destinationFile, fieldValues, callback) {
-            this.fillFormWithFlatten( sourceFile, destinationFile, fieldValues, true, callback);
+        fillForm: function (sourceFile, destinationFile, fieldValues, callback) {
+            this.fillFormWithFlatten(sourceFile, destinationFile, fieldValues, true, callback);
         }
 
     };

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "pdf"
   ],
   "dependencies": {
-    "lodash": "~3.8.0",
+    "lodash": "^4.17.4",
     "utf8-fdf-generator": "0.0.3"
   },
   "author": {
@@ -30,7 +30,7 @@
   "_from": "whitef0x0/pdffiller",
   "_resolved": "git://github.com/whitef0x0/pdffiller.git#dc344fd81d90d0434dcc253d9ee14e4328b680dd",
   "devDependencies": {
-    "mocha": "~2.4.5",
-    "should": "~6.0.1"
+    "mocha": "^3.2.0",
+    "should": "^11.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "pdf"
   ],
   "dependencies": {
-    "lodash": "^4.17.4",
-    "utf8-fdf-generator": "0.0.3"
+    "lodash": "^4.17.4"    
   },
   "author": {
     "name": "John Taylor and David Baldwynn"

--- a/test/test.js
+++ b/test/test.js
@@ -24,7 +24,7 @@ describe('pdfFiller Tests', function(){
 
         var _data = {
             "first_name" : "1) John",
-            "last_name" : "(2) Doe",
+            "last_name" : "Doe",
             "date" : "Jan 1, 2013",
             "football" : "Off",
             "baseball" : "Yes",

--- a/test/test.js
+++ b/test/test.js
@@ -23,8 +23,8 @@ describe('pdfFiller Tests', function(){
     describe('fillForm()', function(){
 
         var _data = {
-            "first_name" : "John",
-            "last_name" : "Doe",
+            "first_name" : "1) John",
+            "last_name" : "(2) Doe",
             "date" : "Jan 1, 2013",
             "football" : "Off",
             "baseball" : "Yes",


### PR DESCRIPTION
Hi All,
Thanks so much for the lib.  It saved me so much time. 

A customer discovered that if they entered a ( or ) in a text field that would be saved to a pdf, then it would crash.  We traced the bug back to this library and finally back to the utf8-fdf-generator lib.

The problem is that in the FDF spec (, ) and \ need to be escaped with a \.  That's a simple enough change, but the utf8-fdf-generator was converting the values to UTF-16  and then back to UTF-8 on file save.  This ended up creating corrupted FDF files.

Long story short, it was easier for me to port in the generator lib and fix it here since this project has unit tests and they are both MIT license.  I put in a pull request for the generator lib, but it hasn't been updated in 4 years and the author isn't on github much, so I don't know how long it will be before its pulled.

I also updated the libs and modified the unit tests to show the bug and the fixes.

If you don't want to merge this, I totally understand since it's really an upstream problem.  I thought it would be helpful to anyone else that runs across this issue.

Thanks again,
James
